### PR TITLE
Updated export_sets.py

### DIFF
--- a/lib/common/wdr/export_sets.py
+++ b/lib/common/wdr/export_sets.py
@@ -1584,7 +1584,7 @@ def services():
                 d(attribute='factories'),
                 d(attribute='properties'),
                 d(attribute='transportChannels'),
-                d(ref='chains'),
+                d(attribute='chains'),
             ],
         ),
         Chain=d(


### PR DESCRIPTION
Under 'TransportChannelService' type attribute called 'chains' should be a regular attribute instead of 'ref'
